### PR TITLE
[FF-4]  Flag 로더, 레지스트리, 리로더 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,10 @@ dependencies {
     implementation("org.springframework:spring-context")
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.18.2")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2")
+    implementation("jakarta.annotation:jakarta.annotation-api")
+    implementation("org.slf4j:slf4j-api:2.0.17")
 
     // 테스트 의존성
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/org/innercircle/simplefeatureflags/internal/FlagLoader.kt
+++ b/src/main/kotlin/org/innercircle/simplefeatureflags/internal/FlagLoader.kt
@@ -1,0 +1,48 @@
+package org.innercircle.simplefeatureflags.internal
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.core.io.ResourceLoader
+import java.io.FileNotFoundException
+import java.io.IOException
+
+internal class FlagLoader(
+    private val resourceLoader: ResourceLoader,
+    private val objectMapper: ObjectMapper
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * 지정된 위치에서 feature flags JSON 파일을 로드하고 파싱하여 Map으로 반환합니다.
+     * @param location feature_flags.json 리소스 위치
+     * @return 파싱된 플래그 맵
+     * @throws FileNotFoundException 파일을 찾을 수 없을 때
+     * @throws JsonProcessingException JSON 파싱 실패
+     * @throws IOException 파일 읽기 실패 시
+     */
+    fun loadFlags(location: String): Map<String, Boolean> {
+        log.debug("Attempting to load feature flags.")
+        val resource = resourceLoader.getResource(location)
+
+        if (!resource.exists()) {
+            log.warn("Feature flag resource not found.")
+            throw FileNotFoundException("Feature flag resource not found.")
+        }
+
+        return try {
+            resource.inputStream.use { inputStream ->
+                val typeRef = object : TypeReference<Map<String, Boolean>>() {}
+                val flags: Map<String, Boolean> = objectMapper.readValue(inputStream, typeRef)
+                flags
+            }
+        } catch (e: JsonProcessingException) {
+            log.error("Failed to parse feature flag resource at location.", e)
+            throw RuntimeException("Failed to parse feature flags from JSON.", e)
+        } catch (e: IOException) {
+            log.error("Failed to read feature flag resource.", e)
+            throw RuntimeException("Failed to read feature flags.", e)
+        }
+    }
+}

--- a/src/main/kotlin/org/innercircle/simplefeatureflags/internal/FlagRegistry.kt
+++ b/src/main/kotlin/org/innercircle/simplefeatureflags/internal/FlagRegistry.kt
@@ -1,0 +1,28 @@
+package org.innercircle.simplefeatureflags.internal
+
+import java.util.concurrent.ConcurrentHashMap
+
+internal class FlagRegistry {
+
+    private val flags: MutableMap<String, Boolean> = ConcurrentHashMap()
+
+    /**
+     * 주어진 플래그 이름에 대한 활성화 상태를 반환합니다.
+     * 플래그가 정의되지 않은 경우 false를 디폴트값으로 반환합니다.
+     * @param flagName 확인할 피처 플래그 이름
+     * @return 활성화 여부
+     */
+    fun isEnabled(flagName: String): Boolean {
+        return flags.getOrDefault(flagName, false)
+    }
+
+    /**
+     * 기존 정보는 초기화됩니다.
+     * 로드된 플래그 정보를 업데이트합니다.
+     * @param loadedFlags 새로 로드된 플래그 맵
+     */
+    fun updateFlags(loadedFlags: Map<String, Boolean>) {
+        flags.clear()
+        flags.putAll(loadedFlags)
+    }
+}

--- a/src/main/kotlin/org/innercircle/simplefeatureflags/internal/FlagReloader.kt
+++ b/src/main/kotlin/org/innercircle/simplefeatureflags/internal/FlagReloader.kt
@@ -1,0 +1,71 @@
+package org.innercircle.simplefeatureflags.internal
+
+import org.innercircle.simplefeatureflags.autoconfigure.SimpleFlagsProperties
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+
+internal class FlagReloader(
+    private val properties: SimpleFlagsProperties,
+    private val flagLoader: FlagLoader,
+    private val flagRegistry: FlagRegistry,
+    private val clock: Clock,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val lastReloadAttemptTime = AtomicReference(Instant.MIN)
+
+    /**
+     * 1. 최소 간격 체크
+     * 2. 마지막 시도 시간 업데이트 시도
+     * 3. 실제 리로드 로직 수행
+     */
+    @Scheduled(cron = "\${simple.flags.reload-cron}")
+    fun reloadFlagsPeriodically() {
+        val now = clock.instant()
+        val lastAttempt = lastReloadAttemptTime.get()
+
+        if (shouldSkipReloadDueToInterval(now, lastAttempt)) {
+            return
+        }
+
+        if (!tryUpdateLastAttemptTime(lastAttempt, now)) {
+            return
+        }
+
+        log.info("Scheduled reload triggered for feature flags.")
+        performReload()
+    }
+
+    /**
+     * 현재 시간과 마지막 시도 시간을 비교하여 최소 리로드 간격이 지났는지 확인합니다,
+     * 지나지 않았으면 true를 반환하여 이번 주기를 스킵합니다.
+     */
+    private fun shouldSkipReloadDueToInterval(now: Instant, lastAttempt: Instant): Boolean {
+        val durationSinceLastAttempt = Duration.between(lastAttempt, now)
+        return durationSinceLastAttempt.seconds < properties.reloadIntervalSeconds
+    }
+
+    /**
+     * Compare-and-Swap을 사용하여 마지막 리로드 시도 시간을 업데이트하려고 시도합니다.
+     * 업데이트 성공 시 true, 실패(동시 접근) 시 false를 반환하여 이번 주기를 스킵합니다..
+     */
+    private fun tryUpdateLastAttemptTime(expectedTime: Instant, newTime: Instant): Boolean {
+        return lastReloadAttemptTime.compareAndSet(expectedTime, newTime)
+    }
+
+    /**
+     * 실제 플래그 로딩 및 레지스트리 업데이트 로직을 수행합니다.
+     */
+    private fun performReload() {
+        try {
+            val loadedFlags = flagLoader.loadFlags(properties.location)
+            flagRegistry.updateFlags(loadedFlags)
+            log.info("Feature flags reloaded successfully.")
+        } catch (e: Exception) {
+            log.error("Failed to reload feature flags.")
+        }
+    }
+}


### PR DESCRIPTION
## 작업사항
Flag 로더, 레지스트리, 리로더를 추가합니다.

## 각 객체의 기능
- 로더는 사용자가 설정한 location에 존재하는 feature_flags.json 리소스를 가져와서 Map으로 전환합니다.
- 레지스트리는 Map에 flag의 사용여부를 체크하고 flag 업데이트를 진행합니다.
- 리로더는 사용자가 동적 리로딩을 허용하면, 설정된 시간 간격마다 스케줄러가 동작하며 로더와 레지스트리의 과정이 반복됩니다.