### PR TITLE
[FF-5] auto configure 관련 빈 등록 및 필요한 property 정의

### DIFF
--- a/src/main/kotlin/org/innercircle/simplefeatureflags/autoconfigure/SimpleFlagsAutoConfiguration.kt
+++ b/src/main/kotlin/org/innercircle/simplefeatureflags/autoconfigure/SimpleFlagsAutoConfiguration.kt
@@ -1,0 +1,61 @@
+package org.innercircle.simplefeatureflags.autoconfigure
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.annotation.PostConstruct
+import org.innercircle.simplefeatureflags.internal.FlagLoader
+import org.innercircle.simplefeatureflags.internal.FlagRegistry
+import org.innercircle.simplefeatureflags.internal.FlagReloader
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ResourceLoader
+import java.time.Clock
+
+@Configuration
+@EnableConfigurationProperties(SimpleFlagsProperties::class)
+class SimpleFlagsAutoConfiguration(
+    private val properties: SimpleFlagsProperties,
+    private val resourceLoader: ResourceLoader,
+    private val objectMapper: ObjectMapper
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Bean
+    @ConditionalOnMissingBean
+    internal fun simpleFlagsSystemClock(): Clock {
+        return Clock.systemUTC()
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    internal fun flagRegistry(): FlagRegistry {
+        return FlagRegistry()
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    internal fun flagLoader(): FlagLoader {
+        return FlagLoader(resourceLoader, objectMapper)
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "simple.flags", name = ["dynamic-reloading-enabled"], havingValue = "true", matchIfMissing = true)
+    @ConditionalOnMissingBean
+    internal fun flagReloader(flagLoader: FlagLoader, flagRegistry: FlagRegistry, clock: Clock): FlagReloader {
+        return FlagReloader(properties, flagLoader, flagRegistry, clock)
+    }
+
+    @PostConstruct
+    internal fun initializeFlags(flagLoader: FlagLoader, flagRegistry: FlagRegistry) {
+        log.info("Initializing Simple Flags from location: {}", properties.location)
+        try {
+            val loadedFlags = flagLoader.loadFlags(properties.location)
+            flagRegistry.updateFlags(loadedFlags)
+        } catch (e: Exception) {
+            log.error("Failed to initialize feature flags.")
+        }
+    }
+}

--- a/src/main/kotlin/org/innercircle/simplefeatureflags/autoconfigure/SimpleFlagsProperties.kt
+++ b/src/main/kotlin/org/innercircle/simplefeatureflags/autoconfigure/SimpleFlagsProperties.kt
@@ -1,0 +1,17 @@
+package org.innercircle.simplefeatureflags.autoconfigure
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * location: feature_flags.json의 위치를 지정합니다.
+ * dynamicReloadingEnabled: true로 설정하면, 플래그가 변경될 때마다 자동으로 리로드됩니다.
+ * reloadCron: 리로드 주기를 설정합니다. default는 매 분마다 리로드됩니다.
+ * reloadIntervalSeconds: 리로드 간격을 초 단위로 설정합니다. 기본값은 20초입니다.
+ */
+@ConfigurationProperties(prefix = "simple.flags")
+data class SimpleFlagsProperties(
+    var location: String,
+    var dynamicReloadingEnabled: Boolean = true,
+    var reloadCron: String = "0 * * * * ?",
+    var reloadIntervalSeconds: Long = 20L
+)


### PR DESCRIPTION
## 작업사항
사용자가 라이브러리 사용 시, auto configure 되도록 하는 Bean들을 정의합니다. 
- 이때 location은 디폴트값이 없으므로 반드시 사용자가 설정해줘야합니다.
- Flag 로더, 레지스트리, 리로더를 Bean으로 등록합니다.
- 시간 관련 테스트를 위해 추가로 Clock을 Bean으로 등록합니다.