### PR TITLE
[FF-6] 특정 플래그의 사용여부를 알 수 있는 interface 및 Default 구현체 추가

### DIFF
--- a/src/main/kotlin/org/innercircle/simplefeatureflags/autoconfigure/SimpleFlagsAutoConfiguration.kt
+++ b/src/main/kotlin/org/innercircle/simplefeatureflags/autoconfigure/SimpleFlagsAutoConfiguration.kt
@@ -48,6 +48,14 @@ class SimpleFlagsAutoConfiguration(
         return FlagReloader(properties, flagLoader, flagRegistry, clock)
     }
 
+    @Bean
+    @ConditionalOnMissingBean(FeatureFlagService::class)
+    internal fun simpleFlagsFeatureFlagService(flagRegistry: FlagRegistry): FeatureFlagService {
+        return DefaultFeatureFlagService(
+            flagRegistry
+        )
+    }
+
     @PostConstruct
     internal fun initializeFlags(flagLoader: FlagLoader, flagRegistry: FlagRegistry) {
         log.info("Initializing Simple Flags from location: {}", properties.location)

--- a/src/main/kotlin/org/innercircle/simplefeatureflags/internal/DefaultFeatureFlagService.kt
+++ b/src/main/kotlin/org/innercircle/simplefeatureflags/internal/DefaultFeatureFlagService.kt
@@ -1,0 +1,20 @@
+package org.innercircle.simplefeatureflags.internal
+
+import org.innercircle.simplefeatureflags.service.FeatureFlagService
+
+/**
+ * FeatureFlagService 인터페이스의 기본 내부 구현체.
+ * FlagRegistry를 사용하여 플래그 상태를 조회합니다.
+ */
+internal class DefaultFeatureFlagService(
+    private val flagRegistry: FlagRegistry
+) : FeatureFlagService {
+
+    /**
+     * FlagRegistry를 통해 플래그 활성화 여부를 조회합니다.
+     * 플래그가 레지스트리에 정의되지 않은 경우, 디폴트 값인 false를 반환합니다.
+     */
+    override fun isEnabled(flagName: String): Boolean {
+        return flagRegistry.isEnabled(flagName)
+    }
+}

--- a/src/main/kotlin/org/innercircle/simplefeatureflags/service/FeatureFlagService.kt
+++ b/src/main/kotlin/org/innercircle/simplefeatureflags/service/FeatureFlagService.kt
@@ -1,0 +1,17 @@
+package org.innercircle.simplefeatureflags.service
+
+interface FeatureFlagService {
+    /**
+     * 지정된 이름의 피처 플래그가 활성화되었는지 확인합니다.
+     *
+     * @param flagName 확인할 피처 플래그의 이름.
+     * @return 플래그가 활성화되어 있으면 true, 그렇지 않으면 false.
+     */
+    fun isEnabled(flagName: String): Boolean
+
+    /**
+     * 지정된 이름의 피처 플래그가 비활성화되었는지 확인합니다.
+     * isEnabled와 거의 동일한 기능이지만 사용하는 곳에서 !를 사용하는 것을 피하기 위해 추가했습니다.
+     */
+    fun isDisabled(flagName: String): Boolean = !isEnabled(flagName)
+}


### PR DESCRIPTION
## 작업내용
플래그의 사용 여부를 판단할 수 있는 인터페이스를 정의하고 구현체를 구현합니다.
- 현재 라이브러리는 파일 기반 json 로드 방식만 지원하므로 디폴트 구현체는 flagRegistry를 사용합니다.

추가로, autoconfigure 세팅을 추가합니다.