### PR TITLE
[FF-7] auto cofiguration 추가 설정

### DIFF
--- a/src/main/kotlin/org/innercircle/simplefeatureflags/autoconfigure/SimpleFlagsAutoConfiguration.kt
+++ b/src/main/kotlin/org/innercircle/simplefeatureflags/autoconfigure/SimpleFlagsAutoConfiguration.kt
@@ -2,10 +2,13 @@ package org.innercircle.simplefeatureflags.autoconfigure
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.annotation.PostConstruct
+import org.innercircle.simplefeatureflags.internal.DefaultFeatureFlagService
 import org.innercircle.simplefeatureflags.internal.FlagLoader
 import org.innercircle.simplefeatureflags.internal.FlagRegistry
 import org.innercircle.simplefeatureflags.internal.FlagReloader
+import org.innercircle.simplefeatureflags.service.FeatureFlagService
 import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -25,18 +28,21 @@ class SimpleFlagsAutoConfiguration(
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnBean(DefaultFeatureFlagService::class)
     internal fun simpleFlagsSystemClock(): Clock {
         return Clock.systemUTC()
     }
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnBean(DefaultFeatureFlagService::class)
     internal fun flagRegistry(): FlagRegistry {
         return FlagRegistry()
     }
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnBean(DefaultFeatureFlagService::class)
     internal fun flagLoader(): FlagLoader {
         return FlagLoader(resourceLoader, objectMapper)
     }

--- a/src/main/kotlin/org/innercircle/simplefeatureflags/autoconfigure/SimpleFlagsAutoConfiguration.kt
+++ b/src/main/kotlin/org/innercircle/simplefeatureflags/autoconfigure/SimpleFlagsAutoConfiguration.kt
@@ -50,6 +50,7 @@ class SimpleFlagsAutoConfiguration(
     @Bean
     @ConditionalOnProperty(prefix = "simple.flags", name = ["dynamic-reloading-enabled"], havingValue = "true", matchIfMissing = true)
     @ConditionalOnMissingBean
+    @ConditionalOnBean(DefaultFeatureFlagService::class)
     internal fun flagReloader(flagLoader: FlagLoader, flagRegistry: FlagRegistry, clock: Clock): FlagReloader {
         return FlagReloader(properties, flagLoader, flagRegistry, clock)
     }


### PR DESCRIPTION
## 작업내용
DefaultFeatureFlagService가 Bean으로 등록되지 않으면 flagRegistry, flagLoader, flagReloader 모두 필요없기 때문에 Bean으로 등록하지 않도록 합니다.